### PR TITLE
Create Spotify Underground Finder mobile app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+SPOTIFY_CLIENT_ID=your_spotify_client_id
+SPOTIFY_REDIRECT_URI=yourapp://redirect
+LASTFM_API_KEY=your_lastfm_api_key

--- a/App.tsx
+++ b/App.tsx
@@ -1,0 +1,373 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Button,
+  SafeAreaView,
+  ScrollView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+  Alert,
+} from 'react-native';
+import { Picker } from '@react-native-picker/picker';
+import { FeatureCard } from './src/components/FeatureCard';
+import { ResultList } from './src/components/ResultList';
+import { useSpotifyAuth } from './src/hooks/useSpotifyAuth';
+import { getUserTopArtists } from './src/api/lastfm';
+import {
+  SpotifyArtist,
+  SpotifyTrack,
+  getArtistByNameWithTracks,
+  getPlaylistBasedRecommendations,
+  getRelatedArtists,
+  getUserPlaylists,
+  searchArtist,
+  getArtistUndergroundTracks,
+} from './src/api/spotify';
+
+export default function App() {
+  const { accessToken, ensureValidToken, isAuthenticating, signIn, signOut, userProfile } = useSpotifyAuth();
+
+  const [lastFmUsername, setLastFmUsername] = useState('');
+  const [lastFmRecommendations, setLastFmRecommendations] = useState<SpotifyArtist[]>([]);
+  const [lastFmLoading, setLastFmLoading] = useState(false);
+
+  const [artistQuery, setArtistQuery] = useState('');
+  const [artistRecommendations, setArtistRecommendations] = useState<SpotifyArtist[]>([]);
+  const [artistLoading, setArtistLoading] = useState(false);
+
+  const [favoriteArtist, setFavoriteArtist] = useState('');
+  const [favoriteTracks, setFavoriteTracks] = useState<SpotifyTrack[]>([]);
+  const [favoriteLoading, setFavoriteLoading] = useState(false);
+
+  const [playlists, setPlaylists] = useState<any[]>([]);
+  const [selectedPlaylist, setSelectedPlaylist] = useState<string>('');
+  const [playlistRecommendations, setPlaylistRecommendations] = useState<SpotifyTrack[]>([]);
+  const [playlistLoading, setPlaylistLoading] = useState(false);
+
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const withToken = useCallback(async () => {
+    const token = await ensureValidToken();
+    if (!token) {
+      Alert.alert('Spotify', 'Please sign in to Spotify to continue.');
+    }
+    return token;
+  }, [ensureValidToken]);
+
+  const handleLastFmRecommendations = useCallback(async () => {
+    if (!lastFmUsername.trim()) {
+      Alert.alert('Last.fm', 'Enter your Last.fm username to continue.');
+      return;
+    }
+
+    const token = await withToken();
+    if (!token) {
+      return;
+    }
+
+    try {
+      setLastFmLoading(true);
+      setErrorMessage(null);
+      const topArtists = await getUserTopArtists(lastFmUsername.trim());
+      const relatedArtists: SpotifyArtist[] = [];
+
+      for (const artistName of topArtists) {
+        const spotifyArtists = await searchArtist(token, artistName);
+        if (!spotifyArtists.length) {
+          continue;
+        }
+
+        const underground = await getRelatedArtists(token, spotifyArtists[0].id);
+        relatedArtists.push(...underground);
+      }
+
+      const unique = Array.from(new Map(relatedArtists.map((artist) => [artist.id, artist])).values()).slice(0, 20);
+      setLastFmRecommendations(unique);
+    } catch (error: any) {
+      console.error(error);
+      setErrorMessage(error.message ?? 'Unable to load recommendations from Last.fm.');
+    } finally {
+      setLastFmLoading(false);
+    }
+  }, [lastFmUsername, withToken]);
+
+  const handleArtistRecommendations = useCallback(async () => {
+    if (!artistQuery.trim()) {
+      Alert.alert('Search', 'Enter an artist name to get recommendations.');
+      return;
+    }
+
+    const token = await withToken();
+    if (!token) {
+      return;
+    }
+
+    try {
+      setArtistLoading(true);
+      setErrorMessage(null);
+      const artists = await searchArtist(token, artistQuery.trim());
+      if (!artists.length) {
+        setArtistRecommendations([]);
+        Alert.alert('Spotify', 'No artists found. Try another search.');
+        return;
+      }
+
+      const related = await getRelatedArtists(token, artists[0].id);
+      setArtistRecommendations(related);
+    } catch (error: any) {
+      console.error(error);
+      setErrorMessage(error.message ?? 'Unable to fetch artist recommendations.');
+    } finally {
+      setArtistLoading(false);
+    }
+  }, [artistQuery, withToken]);
+
+  const handleFavoriteArtistTracks = useCallback(async () => {
+    if (!favoriteArtist.trim()) {
+      Alert.alert('Artist', 'Enter your favorite artist.');
+      return;
+    }
+
+    const token = await withToken();
+    if (!token) {
+      return;
+    }
+
+    try {
+      setFavoriteLoading(true);
+      setErrorMessage(null);
+      const data = await getArtistByNameWithTracks(token, favoriteArtist.trim());
+
+      if (!data) {
+        setFavoriteTracks([]);
+        Alert.alert('Spotify', 'No tracks found for that artist.');
+        return;
+      }
+
+      if (!data.undergroundTracks.length) {
+        const fallback = await getArtistUndergroundTracks(token, data.artist.name);
+        setFavoriteTracks(fallback);
+      } else {
+        setFavoriteTracks(data.undergroundTracks);
+      }
+    } catch (error: any) {
+      console.error(error);
+      setErrorMessage(error.message ?? 'Unable to load underground tracks.');
+    } finally {
+      setFavoriteLoading(false);
+    }
+  }, [favoriteArtist, withToken]);
+
+  const handlePlaylistRecommendations = useCallback(async () => {
+    if (!selectedPlaylist) {
+      Alert.alert('Playlists', 'Select one of your playlists first.');
+      return;
+    }
+
+    const token = await withToken();
+    if (!token) {
+      return;
+    }
+
+    try {
+      setPlaylistLoading(true);
+      setErrorMessage(null);
+      const recommendations = await getPlaylistBasedRecommendations(token, selectedPlaylist);
+      setPlaylistRecommendations(recommendations);
+    } catch (error: any) {
+      console.error(error);
+      setErrorMessage(error.message ?? 'Unable to fetch playlist-based recommendations.');
+    } finally {
+      setPlaylistLoading(false);
+    }
+  }, [selectedPlaylist, withToken]);
+
+  useEffect(() => {
+    const loadPlaylists = async () => {
+      if (!accessToken) {
+        setPlaylists([]);
+        return;
+      }
+
+      try {
+        const token = await withToken();
+        if (!token) {
+          return;
+        }
+
+        const data = await getUserPlaylists(token);
+        setPlaylists(data);
+        if (data.length) {
+          setSelectedPlaylist(data[0].id);
+        }
+      } catch (error: any) {
+        console.error(error);
+        setErrorMessage(error.message ?? 'Unable to load playlists.');
+      }
+    };
+
+    void loadPlaylists();
+  }, [accessToken, withToken]);
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <StatusBar barStyle="light-content" />
+      <ScrollView contentContainerStyle={styles.container}>
+        <Text style={styles.heading}>Spotify Underground Finder</Text>
+        <Text style={styles.subheading}>
+          Discover lesser-known artists and tracks tailored to your taste. Connect your Spotify account to get started.
+        </Text>
+
+        <View style={styles.authRow}>
+          {userProfile ? (
+            <View style={styles.profileRow}>
+              <Text style={styles.profileName}>Signed in as {userProfile.display_name ?? userProfile.id}</Text>
+              <Button title="Sign out" onPress={signOut} color="#f97316" />
+            </View>
+          ) : (
+            <Button title={isAuthenticating ? 'Opening Spotify…' : 'Sign in with Spotify'} onPress={signIn} disabled={isAuthenticating} />
+          )}
+        </View>
+
+        {errorMessage ? <Text style={styles.error}>{errorMessage}</Text> : null}
+
+        <FeatureCard
+          title="1. Last.fm-powered Underground Picks"
+          description="Connect your Spotify account, enter your Last.fm username, and we will surface related underground artists based on your listening history."
+        >
+          <TextInput
+            placeholder="Last.fm username"
+            placeholderTextColor="#94A3B8"
+            style={styles.input}
+            value={lastFmUsername}
+            onChangeText={setLastFmUsername}
+          />
+          <Button title="Find underground matches" onPress={handleLastFmRecommendations} disabled={lastFmLoading} />
+          {lastFmLoading ? <ActivityIndicator color="#38bdf8" /> : null}
+          <ResultList artists={lastFmRecommendations} />
+        </FeatureCard>
+
+        <FeatureCard
+          title="2. Related Underground Artists"
+          description="Search any artist to uncover similar acts flying under the radar."
+        >
+          <TextInput
+            placeholder="Artist name"
+            placeholderTextColor="#94A3B8"
+            style={styles.input}
+            value={artistQuery}
+            onChangeText={setArtistQuery}
+          />
+          <Button title="Get recommendations" onPress={handleArtistRecommendations} disabled={artistLoading} />
+          {artistLoading ? <ActivityIndicator color="#38bdf8" /> : null}
+          <ResultList artists={artistRecommendations} />
+        </FeatureCard>
+
+        <FeatureCard
+          title="3. Hidden Gems from Your Favorite Artist"
+          description="We will dig into an artist's catalog to surface songs with lower popularity and streams."
+        >
+          <TextInput
+            placeholder="Favorite artist"
+            placeholderTextColor="#94A3B8"
+            style={styles.input}
+            value={favoriteArtist}
+            onChangeText={setFavoriteArtist}
+          />
+          <Button title="Find underground songs" onPress={handleFavoriteArtistTracks} disabled={favoriteLoading} />
+          {favoriteLoading ? <ActivityIndicator color="#38bdf8" /> : null}
+          <ResultList tracks={favoriteTracks} />
+        </FeatureCard>
+
+        <FeatureCard
+          title="4. Playlist-based Discoveries"
+          description="Choose one of your playlists and we'll recommend underground tracks inspired by it."
+        >
+          {accessToken ? (
+            <View style={styles.pickerWrapper}>
+              <Picker
+                selectedValue={selectedPlaylist}
+                onValueChange={(value) => setSelectedPlaylist(value)}
+                dropdownIconColor="#F8FAFC"
+                style={styles.picker}
+              >
+                {playlists.map((playlist) => (
+                  <Picker.Item label={playlist.name} value={playlist.id} key={playlist.id} color="#0F172A" />
+                ))}
+              </Picker>
+            </View>
+          ) : (
+            <Text style={styles.hint}>Sign in with Spotify to load your playlists.</Text>
+          )}
+          <Button title="Get underground recommendations" onPress={handlePlaylistRecommendations} disabled={playlistLoading} />
+          {playlistLoading ? <ActivityIndicator color="#38bdf8" /> : null}
+          <ResultList tracks={playlistRecommendations} />
+        </FeatureCard>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#020617',
+  },
+  container: {
+    padding: 20,
+    paddingBottom: 48,
+    backgroundColor: '#020617',
+  },
+  heading: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#F8FAFC',
+    marginBottom: 8,
+  },
+  subheading: {
+    color: '#CBD5F5',
+    marginBottom: 24,
+    fontSize: 16,
+    lineHeight: 22,
+  },
+  authRow: {
+    marginBottom: 24,
+  },
+  profileRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  profileName: {
+    color: '#F8FAFC',
+    fontWeight: '500',
+    flex: 1,
+  },
+  input: {
+    backgroundColor: 'rgba(15, 23, 42, 0.9)',
+    color: '#F8FAFC',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 12,
+  },
+  pickerWrapper: {
+    backgroundColor: '#F8FAFC',
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  picker: {
+    color: '#0F172A',
+  },
+  hint: {
+    color: '#94A3B8',
+    marginBottom: 12,
+  },
+  error: {
+    color: '#f87171',
+    marginBottom: 16,
+  },
+});

--- a/README.md
+++ b/README.md
@@ -1,1 +1,86 @@
-# resonance
+# Spotify Underground Finder
+
+A React Native (Expo) mobile app that helps you uncover underground artists and tracks on Spotify using a mix of Spotify and Last.fm data.
+
+## Features
+
+1. **Last.fm powered suggestions** – authenticate with Spotify, enter your Last.fm username, and receive underground artist recommendations based on your listening history.
+2. **Artist-based exploration** – input any artist and discover related acts with Spotify popularity under 40.
+3. **Hidden gems from favourites** – surface lesser-known songs by your favourite artists.
+4. **Playlist intelligence** – pick one of your Spotify playlists and get underground artist and track recommendations tailored to it.
+5. **Quick listening** – every result includes a "Listen on Spotify" deep link.
+
+The UI is designed to be clean, mobile-first, and friendly to use.
+
+## Prerequisites
+
+- [Node.js 18+](https://nodejs.org/)
+- [Expo CLI](https://docs.expo.dev/get-started/installation/) (`npm install -g expo-cli`)
+- Spotify Developer account with a registered application
+- Last.fm API key
+
+## Getting Started
+
+1. **Install dependencies**
+
+   ```bash
+   npm install
+   ```
+
+2. **Create your environment file**
+
+   Duplicate `.env.example` and fill in your credentials:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   | Variable | Description |
+   | --- | --- |
+   | `SPOTIFY_CLIENT_ID` | Client ID from your Spotify application |
+   | `SPOTIFY_REDIRECT_URI` | Redirect URI registered for your Spotify app (e.g. `spotify-underground-finder://redirect`) |
+   | `LASTFM_API_KEY` | Your Last.fm API key |
+
+3. **Update Spotify app settings**
+
+   - Add the redirect URI you used above to your Spotify app's list of redirect URIs.
+   - Enable the following scopes: `user-read-email`, `user-read-private`, `playlist-read-private`, `playlist-read-collaborative`, `user-library-read`.
+
+4. **Run the app**
+
+   ```bash
+   npm run start
+   ```
+
+   Then follow the Expo CLI instructions to open the app on iOS, Android, or web.
+
+## Project Structure
+
+```
+├── App.tsx                  # Main application with UI and feature orchestration
+├── src
+│   ├── api
+│   │   ├── lastfm.ts        # Last.fm API helpers
+│   │   └── spotify.ts       # Spotify API helpers and models
+│   ├── components
+│   │   ├── FeatureCard.tsx  # Simple card wrapper for each feature
+│   │   └── ResultList.tsx   # Reusable list rendering artists/tracks with Spotify links
+│   ├── constants
+│   │   └── config.ts        # Shared constants and thresholds
+│   └── hooks
+│       └── useSpotifyAuth.ts# Spotify OAuth flow handled with expo-auth-session
+├── app.config.ts            # Expo configuration with environment variables
+├── tsconfig.json
+└── package.json
+```
+
+## Notes
+
+- The app uses Spotify's PKCE OAuth flow, so a client secret is not required on mobile.
+- Last.fm requests rely on the username you provide. Make sure the account is scrobbling your Spotify listening history so the recommendations feel personal.
+- All Spotify data is filtered using a popularity threshold of **40** to emphasise underground content.
+- Error handling and messaging are included, but you should still expect rate limits if you make a large number of requests quickly.
+
+## Testing
+
+This project currently relies on manual testing through the Expo client. Add automated tests (e.g., Jest + React Native Testing Library) as the codebase grows.

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,0 +1,28 @@
+import 'dotenv/config';
+import type { ExpoConfig } from '@expo/config-types';
+
+export default ({ config }: { config: ExpoConfig }): ExpoConfig => ({
+  ...config,
+  name: 'Spotify Underground Finder',
+  slug: 'spotify-underground-finder',
+  scheme: 'spotify-underground-finder',
+  version: '1.0.0',
+  orientation: 'portrait',
+  platforms: ['ios', 'android', 'web'],
+  splash: {
+    backgroundColor: '#0F172A',
+    resizeMode: 'contain'
+  },
+  updates: {
+    fallbackToCacheTimeout: 0
+  },
+  assetBundlePatterns: ['**/*'],
+  extra: {
+    spotifyClientId: process.env.SPOTIFY_CLIENT_ID,
+    spotifyRedirectUri: process.env.SPOTIFY_REDIRECT_URI,
+    lastfmApiKey: process.env.LASTFM_API_KEY
+  },
+  experiments: {
+    tsconfigPaths: true
+  }
+});

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "spotify-underground-finder",
+  "version": "1.0.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@react-native-picker/picker": "^2.4.10",
+    "expo": "^50.0.0",
+    "expo-auth-session": "^5.1.2",
+    "expo-constants": "^15.4.5",
+    "expo-linking": "^5.0.2",
+    "react": "18.2.0",
+    "react-native": "0.73.6"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.0",
+    "@types/react": "~18.2.45",
+    "@types/react-native": "^0.73.0",
+    "typescript": "^5.2.2",
+    "dotenv": "^16.3.1",
+    "@expo/config-types": "^52.0.0"
+  }
+}

--- a/src/api/lastfm.ts
+++ b/src/api/lastfm.ts
@@ -1,0 +1,29 @@
+import { LASTFM_API_KEY, LASTFM_API_ROOT } from '../constants/config';
+
+interface LastFmTopArtist {
+  name: string;
+  playcount: string;
+}
+
+interface LastFmTopArtistsResponse {
+  topartists: {
+    artist: LastFmTopArtist[];
+  };
+}
+
+export const getUserTopArtists = async (username: string, limit = 10) => {
+  if (!LASTFM_API_KEY) {
+    throw new Error('Missing LASTFM_API_KEY. Please configure your environment variables.');
+  }
+
+  const url = `${LASTFM_API_ROOT}?method=user.gettopartists&user=${encodeURIComponent(username)}&api_key=${LASTFM_API_KEY}&format=json&limit=${limit}`;
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`Last.fm API error: ${response.status} ${message}`);
+  }
+
+  const data = (await response.json()) as LastFmTopArtistsResponse;
+  return data.topartists.artist.map((artist) => artist.name);
+};

--- a/src/api/spotify.ts
+++ b/src/api/spotify.ts
@@ -1,0 +1,137 @@
+import { SPOTIFY_API_ROOT, UNDERGROUND_POPULARITY_THRESHOLD } from '../constants/config';
+
+export interface SpotifyArtist {
+  id: string;
+  name: string;
+  popularity: number;
+  genres: string[];
+  images?: { url: string }[];
+  external_urls?: { spotify?: string };
+}
+
+export interface SpotifyTrack {
+  id: string;
+  name: string;
+  popularity: number;
+  external_urls?: { spotify?: string };
+  artists: SpotifyArtist[];
+  album?: { images?: { url: string }[] };
+}
+
+const fetchFromSpotify = async <T>(token: string, endpoint: string, options?: RequestInit): Promise<T> => {
+  const url = endpoint.startsWith('http') ? endpoint : `${SPOTIFY_API_ROOT}${endpoint}`;
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...(options?.headers ?? {}),
+    },
+  });
+
+  if (response.status === 204) {
+    return {} as T;
+  }
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`Spotify API error: ${response.status} ${message}`);
+  }
+
+  return (await response.json()) as T;
+};
+
+export const getUserPlaylists = async (token: string) => {
+  const playlists: any[] = [];
+  let next: string | null = `${SPOTIFY_API_ROOT}/me/playlists?limit=50`;
+
+  while (next) {
+    const page = await fetchFromSpotify<{ items: any[]; next: string | null }>(token, next);
+    playlists.push(...page.items);
+    next = page.next;
+  }
+
+  return playlists;
+};
+
+export const getPlaylistTracks = async (token: string, playlistId: string) => {
+  const tracks: SpotifyTrack[] = [];
+  let next: string | null = `${SPOTIFY_API_ROOT}/playlists/${playlistId}/tracks?limit=100`;
+
+  while (next) {
+    const page = await fetchFromSpotify<{ items: { track: SpotifyTrack | null }[]; next: string | null }>(token, next);
+
+    const pageTracks = page.items
+      .map((item) => item.track)
+      .filter((track): track is SpotifyTrack => Boolean(track));
+
+    tracks.push(...pageTracks);
+    next = page.next;
+  }
+
+  return tracks;
+};
+
+export const searchArtist = async (token: string, query: string) => {
+  const data = await fetchFromSpotify<{ artists: { items: SpotifyArtist[] } }>(
+    token,
+    `/search?type=artist&limit=5&q=${encodeURIComponent(query)}`
+  );
+
+  return data.artists.items;
+};
+
+export const getRelatedArtists = async (token: string, artistId: string) => {
+  const data = await fetchFromSpotify<{ artists: SpotifyArtist[] }>(token, `/artists/${artistId}/related-artists`);
+  return data.artists.filter((artist) => artist.popularity < UNDERGROUND_POPULARITY_THRESHOLD);
+};
+
+export const getArtistUndergroundTracks = async (token: string, artistName: string) => {
+  const data = await fetchFromSpotify<{ tracks: { items: SpotifyTrack[] } }>(
+    token,
+    `/search?type=track&limit=50&q=${encodeURIComponent(`artist:"${artistName}"`)}`
+  );
+
+  return data.tracks.items.filter((track) => track.popularity < UNDERGROUND_POPULARITY_THRESHOLD);
+};
+
+export const getArtistByNameWithTracks = async (token: string, artistName: string) => {
+  const artists = await searchArtist(token, artistName);
+  if (!artists.length) {
+    return null;
+  }
+
+  const artist = artists[0];
+  const undergroundTracks = await getArtistUndergroundTracks(token, artist.name);
+
+  return {
+    artist,
+    undergroundTracks,
+  };
+};
+
+export const getPlaylistBasedRecommendations = async (token: string, playlistId: string) => {
+  const tracks = await getPlaylistTracks(token, playlistId);
+  const seedArtists = Array.from(
+    new Set(
+      tracks
+        .flatMap((track) => track.artists.map((artist) => artist.id))
+        .filter(Boolean)
+    )
+  ).slice(0, 5);
+
+  if (!seedArtists.length) {
+    return [];
+  }
+
+  const data = await fetchFromSpotify<{ tracks: SpotifyTrack[] }>(
+    token,
+    `/recommendations?limit=20&seed_artists=${seedArtists.join(',')}`
+  );
+
+  return data.tracks.filter((track) => track.popularity < UNDERGROUND_POPULARITY_THRESHOLD);
+};
+
+export const getArtistDetails = async (token: string, artistId: string) => {
+  return fetchFromSpotify<SpotifyArtist>(token, `/artists/${artistId}`);
+};

--- a/src/components/FeatureCard.tsx
+++ b/src/components/FeatureCard.tsx
@@ -1,0 +1,40 @@
+import { ReactNode } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+interface FeatureCardProps {
+  title: string;
+  description: string;
+  children: ReactNode;
+}
+
+export const FeatureCard = ({ title, description, children }: FeatureCardProps) => {
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>{title}</Text>
+      <Text style={styles.description}>{description}</Text>
+      <View style={styles.content}>{children}</View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: 'rgba(15, 23, 42, 0.6)',
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 24,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: '#F8FAFC',
+    marginBottom: 4,
+  },
+  description: {
+    color: '#CBD5F5',
+    marginBottom: 12,
+  },
+  content: {
+    gap: 12,
+  },
+});

--- a/src/components/ResultList.tsx
+++ b/src/components/ResultList.tsx
@@ -1,0 +1,80 @@
+import { Linking, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { SpotifyArtist, SpotifyTrack } from '../api/spotify';
+
+interface ResultListProps {
+  artists?: SpotifyArtist[];
+  tracks?: SpotifyTrack[];
+}
+
+const openSpotifyLink = (url?: string) => {
+  if (!url) {
+    return;
+  }
+
+  void Linking.openURL(url);
+};
+
+export const ResultList = ({ artists = [], tracks = [] }: ResultListProps) => {
+  return (
+    <View style={styles.container}>
+      {artists.map((artist) => (
+        <TouchableOpacity
+          key={artist.id}
+          onPress={() => openSpotifyLink(artist.external_urls?.spotify)}
+          style={styles.item}
+        >
+          <Text style={styles.itemTitle}>{artist.name}</Text>
+          <Text style={styles.meta}>Popularity: {artist.popularity}</Text>
+          {artist.genres?.length ? <Text style={styles.meta}>Genres: {artist.genres.slice(0, 3).join(', ')}</Text> : null}
+          <Text style={styles.link}>Listen on Spotify</Text>
+        </TouchableOpacity>
+      ))}
+
+      {tracks.map((track) => (
+        <TouchableOpacity
+          key={track.id}
+          onPress={() => openSpotifyLink(track.external_urls?.spotify)}
+          style={styles.item}
+        >
+          <Text style={styles.itemTitle}>{track.name}</Text>
+          <Text style={styles.meta}>
+            {track.artists.map((artist) => artist.name).join(', ')} · Popularity {track.popularity}
+          </Text>
+          <Text style={styles.link}>Listen on Spotify</Text>
+        </TouchableOpacity>
+      ))}
+
+      {!artists.length && !tracks.length ? <Text style={styles.empty}>No results yet.</Text> : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 12,
+  },
+  item: {
+    backgroundColor: 'rgba(15, 23, 42, 0.9)',
+    borderRadius: 12,
+    padding: 12,
+  },
+  itemTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#F1F5F9',
+    marginBottom: 4,
+  },
+  meta: {
+    color: '#CBD5F5',
+  },
+  link: {
+    color: '#34D399',
+    marginTop: 8,
+    fontWeight: '500',
+  },
+  empty: {
+    color: '#CBD5F5',
+    textAlign: 'center',
+    paddingVertical: 8,
+  },
+});

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -1,0 +1,12 @@
+import Constants from 'expo-constants';
+
+const config = Constants.expoConfig?.extra ?? {};
+
+export const SPOTIFY_CLIENT_ID = (config.spotifyClientId as string) ?? '';
+export const SPOTIFY_REDIRECT_URI = (config.spotifyRedirectUri as string) ?? '';
+export const LASTFM_API_KEY = (config.lastfmApiKey as string) ?? '';
+
+export const LASTFM_API_ROOT = 'https://ws.audioscrobbler.com/2.0/';
+export const SPOTIFY_API_ROOT = 'https://api.spotify.com/v1';
+
+export const UNDERGROUND_POPULARITY_THRESHOLD = 40;

--- a/src/hooks/useSpotifyAuth.ts
+++ b/src/hooks/useSpotifyAuth.ts
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import * as AuthSession from 'expo-auth-session';
+import { Alert } from 'react-native';
+import { SPOTIFY_CLIENT_ID, SPOTIFY_REDIRECT_URI } from '../constants/config';
+
+const discovery = {
+  authorizationEndpoint: 'https://accounts.spotify.com/authorize',
+  tokenEndpoint: 'https://accounts.spotify.com/api/token',
+};
+
+interface TokenResponse {
+  accessToken: string;
+  refreshToken?: string;
+  expiresIn: number;
+  issuedAt: number;
+}
+
+const defaultScopes = [
+  'user-read-email',
+  'user-read-private',
+  'playlist-read-private',
+  'playlist-read-collaborative',
+  'user-library-read',
+];
+
+export const useSpotifyAuth = () => {
+  const [tokenResponse, setTokenResponse] = useState<TokenResponse | null>(null);
+  const [isAuthenticating, setIsAuthenticating] = useState(false);
+  const [userProfile, setUserProfile] = useState<any>(null);
+
+  const redirectUri = useMemo(() => {
+    if (SPOTIFY_REDIRECT_URI) {
+      return SPOTIFY_REDIRECT_URI;
+    }
+
+    return AuthSession.makeRedirectUri({
+      scheme: 'spotify-underground-finder',
+      preferLocalhost: true,
+    });
+  }, []);
+
+  const [request, response, promptAsync] = AuthSession.useAuthRequest(
+    {
+      clientId: SPOTIFY_CLIENT_ID,
+      redirectUri,
+      scopes: defaultScopes,
+      usePKCE: true,
+    },
+    discovery
+  );
+
+  const fetchUserProfile = useCallback(
+    async (accessToken: string) => {
+      try {
+        const profileResponse = await fetch('https://api.spotify.com/v1/me', {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+
+        if (!profileResponse.ok) {
+          throw new Error('Failed to fetch user profile');
+        }
+
+        const profile = await profileResponse.json();
+        setUserProfile(profile);
+      } catch (error) {
+        console.error(error);
+        Alert.alert('Spotify', 'Unable to load your profile information.');
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    const handleResponse = async () => {
+      if (response?.type === 'success' && request) {
+        try {
+          setIsAuthenticating(true);
+          const { code } = response.params;
+          const tokens = await AuthSession.exchangeCodeAsync(
+            {
+              clientId: SPOTIFY_CLIENT_ID,
+              code,
+              redirectUri,
+              extraParams: {
+                code_verifier: request.codeVerifier || '',
+              },
+            },
+            discovery
+          );
+
+          setTokenResponse({
+            accessToken: tokens.access_token,
+            refreshToken: tokens.refresh_token,
+            expiresIn: tokens.expires_in ?? 3600,
+            issuedAt: Date.now(),
+          });
+          await fetchUserProfile(tokens.access_token);
+        } catch (error) {
+          console.error(error);
+          Alert.alert('Spotify', 'Authentication failed. Please try again.');
+        } finally {
+          setIsAuthenticating(false);
+        }
+      }
+    };
+
+    void handleResponse();
+  }, [response, request, redirectUri, fetchUserProfile]);
+
+  const ensureValidToken = useCallback(async () => {
+    if (!tokenResponse) {
+      return null;
+    }
+
+    const { accessToken, expiresIn, issuedAt, refreshToken } = tokenResponse;
+    const now = Date.now();
+    const isExpired = now - issuedAt >= expiresIn * 1000 - 60000;
+
+    if (!isExpired) {
+      return accessToken;
+    }
+
+    if (!refreshToken) {
+      setTokenResponse(null);
+      return null;
+    }
+
+    try {
+      const refreshed = await AuthSession.refreshAsync(
+        {
+          clientId: SPOTIFY_CLIENT_ID,
+          refreshToken,
+        },
+        discovery
+      );
+
+      const updated: TokenResponse = {
+        accessToken: refreshed.access_token,
+        refreshToken: refreshed.refresh_token ?? refreshToken,
+        expiresIn: refreshed.expires_in ?? 3600,
+        issuedAt: Date.now(),
+      };
+      setTokenResponse(updated);
+      return updated.accessToken;
+    } catch (error) {
+      console.error(error);
+      setTokenResponse(null);
+      Alert.alert('Spotify', 'Session expired. Please sign in again.');
+      return null;
+    }
+  }, [tokenResponse]);
+
+  const signIn = useCallback(async () => {
+    if (!SPOTIFY_CLIENT_ID) {
+      Alert.alert('Configuration missing', 'Set SPOTIFY_CLIENT_ID in your environment.');
+      return;
+    }
+
+    try {
+      setIsAuthenticating(true);
+      await promptAsync();
+    } catch (error) {
+      console.error(error);
+      Alert.alert('Spotify', 'Could not open the login dialog.');
+    } finally {
+      setIsAuthenticating(false);
+    }
+  }, [promptAsync]);
+
+  const signOut = useCallback(() => {
+    setTokenResponse(null);
+    setUserProfile(null);
+  }, []);
+
+  return {
+    accessToken: tokenResponse?.accessToken ?? null,
+    ensureValidToken,
+    isAuthenticating,
+    signIn,
+    signOut,
+    userProfile,
+  };
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "lib": ["dom", "esnext"],
+    "moduleResolution": "node",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "types": ["react", "react-native"]
+  },
+  "extends": "expo/tsconfig.base"
+}


### PR DESCRIPTION
## Summary
- scaffold an Expo-based Spotify Underground Finder mobile experience with dedicated flows for Last.fm history, artist exploration, underground tracks, and playlist-derived picks
- implement Spotify authentication plus Spotify and Last.fm API helpers to surface low-popularity recommendations with deep links back to Spotify
- document environment configuration, tooling, and project structure for running and extending the app

## Testing
- Not run (Expo project setup)


------
https://chatgpt.com/codex/tasks/task_e_68e46d1378d4832bb1f2cd094e1b6d02